### PR TITLE
Add proxy endpoint for Netilab AI

### DIFF
--- a/controllers/queryNetilabAiController.js
+++ b/controllers/queryNetilabAiController.js
@@ -1,0 +1,17 @@
+const queryNetilabAiService = require('../services/queryNetilabAiService');
+
+exports.handleQueryNetilabAi = async (req, res) => {
+  const { text } = req.body;
+
+  if (!text) {
+    return res.status(400).json({ error: 'Text is required' });
+  }
+
+  try {
+    const result = await queryNetilabAiService.queryText(text);
+    return res.json(result);
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ error: 'Failed to query AI service' });
+  }
+};

--- a/routes/queryNetilabAiRoutes.js
+++ b/routes/queryNetilabAiRoutes.js
@@ -1,0 +1,25 @@
+const express = require('express');
+const router = express.Router();
+const queryNetilabAiController = require('../controllers/queryNetilabAiController');
+
+/**
+ * @swagger
+ * /query-netilab-ai/text:
+ *   post:
+ *     summary: Proxy request to python-ai service
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               text:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Successful response
+ */
+router.post('/text', queryNetilabAiController.handleQueryNetilabAi);
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -4,12 +4,14 @@ const port = 3000;
 
 const apiRoutes = require('./routes');
 const asknetilabRoutes = require('./routes/asknetilabRoutes');
+const queryNetilabAiRoutes = require('./routes/queryNetilabAiRoutes');
 const setupSwagger = require('./swagger');
 
 app.use(express.json());
 // Use routes
 app.use('/api', apiRoutes);
 app.use('/asknetilab', asknetilabRoutes);
+app.use('/query-netilab-ai', queryNetilabAiRoutes);
 
 setupSwagger(app);
 

--- a/services/queryNetilabAiService.js
+++ b/services/queryNetilabAiService.js
@@ -1,0 +1,26 @@
+exports.queryText = async (text) => {
+  const payload = {
+    text,
+    top: 5,
+    exact_weight: 1,
+    near_weight: 1,
+    exact_law_weight: 0.5,
+    near_law_weight: 0.5,
+  };
+
+  const response = await fetch('http://python-ai/text/', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      accept: 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(`API request failed: ${response.status} ${message}`);
+  }
+
+  return response.json();
+};


### PR DESCRIPTION
## Summary
- create controller/service/route for `/query-netilab-ai/text`
- proxy requests to `http://python-ai/text/`
- register new route in the Express app

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6871b29eff308324aa5a887a45728114