### PR TITLE
Add docs proxy endpoint

### DIFF
--- a/controllers/queryNetilabAiController.js
+++ b/controllers/queryNetilabAiController.js
@@ -15,3 +15,13 @@ exports.handleQueryNetilabAi = async (req, res) => {
     return res.status(500).json({ error: 'Failed to query AI service' });
   }
 };
+
+exports.handleDocs = async (req, res) => {
+  try {
+    const result = await queryNetilabAiService.getDocs();
+    return res.json(result);
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ error: 'Failed to fetch docs from AI service' });
+  }
+};

--- a/routes/queryNetilabAiRoutes.js
+++ b/routes/queryNetilabAiRoutes.js
@@ -22,4 +22,15 @@ const queryNetilabAiController = require('../controllers/queryNetilabAiControlle
  */
 router.post('/text', queryNetilabAiController.handleQueryNetilabAi);
 
+/**
+ * @swagger
+ * /query-netilab-ai/docs:
+ *   get:
+ *     summary: Retrieve documentation from python-ai service
+ *     responses:
+ *       200:
+ *         description: Successful response
+ */
+router.get('/docs', queryNetilabAiController.handleDocs);
+
 module.exports = router;

--- a/server.js
+++ b/server.js
@@ -16,7 +16,7 @@ app.use('/query-netilab-ai', queryNetilabAiRoutes);
 setupSwagger(app);
 
 app.get('/', (req, res) => {
-    res.send('Hello World! 2.2');
+    res.send('Hello World! 2.3');
 });
 
 app.listen(port, () => {

--- a/services/queryNetilabAiService.js
+++ b/services/queryNetilabAiService.js
@@ -27,3 +27,14 @@ exports.queryText = async (text) => {
 
   return response.json();
 };
+
+exports.getDocs = async () => {
+  const response = await fetch('http://python-ai.com/docs');
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(`API request failed: ${response.status} ${message}`);
+  }
+
+  return response.json();
+};


### PR DESCRIPTION
## Summary
- proxy `GET /query-netilab-ai/docs` to `http://python-ai.com/docs`
- expose new controller/service functions
- document the new route in Swagger

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68724a2b26988324959cb5ea4f4fda21